### PR TITLE
feat: signin/signup pages, auth guard, remove footer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,6 @@ import { GeistMono } from 'geist/font/mono';
 import { GeistSans } from 'geist/font/sans';
 import { Analytics } from '@vercel/analytics/react';
 import { Toaster } from '@/components/ui/toaster';
-import Footer from '@/components/Footer';
 import './globals.css';
 
 import { AI } from './action';
@@ -11,6 +10,7 @@ import { Header } from '@/components/header';
 import { Providers } from '@/components/providers';
 import { AuthProvider } from '@/lib/auth-context';
 import { ThemeProvider } from '@/lib/theme-context';
+import { AuthGuard } from '@/components/AuthGuard';
 
 const meta = {
   title: 'Results, simple and smart.',
@@ -68,13 +68,14 @@ export default function RootLayout({
                 enableSystem
                 disableTransitionOnChange
               >
-                <div className="flex flex-col min-h-screen">
-                  <Header />
-                  <main className="flex flex-col flex-1 bg-muted/50 dark:bg-background px-4 pb-16">
-                    {children}
-                  </main>
-                </div>
-                <Footer />
+                <AuthGuard>
+                  <div className="flex flex-col min-h-screen">
+                    <Header />
+                    <main className="flex flex-col flex-1 bg-muted/50 dark:bg-background px-4 pb-16">
+                      {children}
+                    </main>
+                  </div>
+                </AuthGuard>
               </Providers>
             </ThemeProvider>
           </AI>

--- a/components/AuthGuard.tsx
+++ b/components/AuthGuard.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import { useAuth } from '@/lib/auth-context';
+
+// Routes that don't require authentication
+const PUBLIC_PATHS = ['/signin', '/signup', '/login'];
+
+export function AuthGuard({ children }: { children: React.ReactNode }) {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const isPublic = PUBLIC_PATHS.some((p) => pathname.startsWith(p));
+
+  useEffect(() => {
+    if (!loading && !user && !isPublic) {
+      router.replace('/signin');
+    }
+  }, [user, loading, isPublic, router]);
+
+  // Show nothing while checking auth on protected routes
+  if (!isPublic && (loading || !user)) {
+    return (
+      <div style={{
+        position: 'fixed', inset: 0, background: '#0a0a0a',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 9999,
+      }}>
+        <div style={{
+          width: '28px', height: '28px',
+          border: '2px solid rgba(255,255,255,0.1)',
+          borderTopColor: '#6366f1',
+          borderRadius: '50%',
+          animation: 'spin 0.7s linear infinite',
+        }} />
+        <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- Add dedicated `/signin` and `/signup` pages with lookinit branding and Google sign-in
- Add `AuthGuard` component — redirects unauthenticated users to `/signin` app-wide
- Move Google login from header button to signin/signup pages; header shows plain "Sign in" link
- Remove footer bar (Pro, Enterprise, News, Blog links)

## Test plan
- [ ] Visit app.lookinit.com without signing in → should redirect to `/signin`
- [ ] Sign in with Google on `/signin` → should land on main app
- [ ] Sign in with email/password → should land on main app
- [ ] Sign up with email → should land on main app
- [ ] `/signin` ↔ `/signup` links work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)